### PR TITLE
docs(js): encoding api

### DIFF
--- a/Writerside/e.tree
+++ b/Writerside/e.tree
@@ -61,7 +61,8 @@
                     <toc-element toc-title="Worker threads" />
                     <toc-element toc-title="Zlib" />
                 </toc-element>
-                <toc-element toc-title="Web APIs">
+                <toc-element toc-title="Web &amp; JavaScript APIs">
+                    <toc-element topic="JavaScript-Encoding-API.md"/>
                     <toc-element toc-title="Fetch API" />
                     <toc-element toc-title="URL API" />
                     <toc-element toc-title="Web Crypto API" />

--- a/Writerside/topics/JavaScript-Encoding-API.md
+++ b/Writerside/topics/JavaScript-Encoding-API.md
@@ -1,0 +1,77 @@
+# Encoding API
+
+Elide supports the standard JavaScript types [`TextEncoder`](#textencoder) and [`TextDecoder`](#textdecoder). These
+classes can be used to obtain byte-arrays of strings in different encodings, or to obtain strings from byte arrays with
+different encodings.
+
+## Supported Encodings
+
+Elide supports several encodings via the `TextEncoder` and `TextDecoder` constructors:
+
+| Support               | Charset          | Encoding (Label) | Notes            |
+|-----------------------|------------------|------------------|------------------|
+| 🟢 Supported.         | `ISO_8859_1`     | `iso-8859-1`     |                  |
+| 🟢 Supported.         | `ASCII`          | `ascii`          |                  |
+| 🟢 Supported.         | `UTF_8`          | `utf-8`          | Default encoding |
+| 🔴 Not supported yet. | `UTF_16`         | `utf-16`         |                  |
+| 🔴 Not supported yet. | `UTF_32`         | `utf-32`         |                  |
+| 🔴 Not supported yet. | (Other charsets) |                  |                  |
+
+## Encoding API | Classes
+
+[`TextEncoder`](#textencoder) Encode strings into byte array representations
+: 🟢 Supported.
+
+[`TextDecoder`](#textdecoder) Decode byte arrays into string representations
+: 🟢 Supported.
+
+## `TextEncoder`
+
+```Javascript
+// create an encoder; by default, it uses utf-8
+const encoder = new TextEncoder();
+encoder.encoding         // returns 'utf-8'
+encoder.encode("hello")  // returns `Uint8Array([...])`
+```
+
+The `TextEncoder` class behaves very similarly to how it behaves in a browser, or under Node.js; the only difference is
+that Elide supports additional encodings, on top of the default, which is `utf-8`.
+
+> Read more about [`TextEncoder` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder)
+
+### `TextEncoder` Properties
+
+[`TextEncoder.encoding`](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encoding)
+: 🟢 Supported.
+
+### `TextEncoder` Methods
+
+[`TextEncoder.encode`](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode)
+: 🟢 Supported.
+
+[`TextEncoder.encodeInto`](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encodeInto)
+: 🟢 Supported.
+
+## `TextDecoder`
+
+```Javascript
+// create a decoder; by default, it uses utf-8
+const decoder = new TextDecoder();
+decoder.encoding         // returns 'utf-8'
+const input = new Uint8Array([104, 101, 108, 108, 111]);
+decoder.decode(input)  // returns 'hello'
+```
+
+The `TextDecoder` class behaves identically to how it behaves in a browser, or under Node.js.
+
+> Read more about [`TextDecoder` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder)
+
+### `TextDecoder` Properties
+
+[`TextDecoder.encoding`](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/encoding)
+: 🟢 Supported.
+
+### `TextDecoder` Methods
+
+[`TextDecoder.decode`](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode)
+: 🟢 Supported.

--- a/Writerside/topics/javascript-sqlite.md
+++ b/Writerside/topics/javascript-sqlite.md
@@ -6,7 +6,7 @@ switcher-label: Imports
 
 <tldr>
     <p>Module: <code>elide:sqlite</code></p>
-    <p>Support: <img style="inline" src="https://img.shields.io/badge/-beta-purple" /></p>
+    <p>Support: <img style="inline" src="https://img.shields.io/badge/-beta-purple" alt="beta" /></p>
     <p>Docs: <a href="https://bun.sh/docs/api/sqlite">Bun SQLite Docs</a></p>
 </tldr>
 
@@ -27,6 +27,10 @@ db.query("SELECT * FROM test;").get()["name"]
 
 > Bindings are on the way for Python and Ruby.
 > {style="note"}
+
+## SQLite Examples
+
+Coming soon.
 
 ## `sqlite` | Classes
 


### PR DESCRIPTION
## Changelog

- docs(js): add doc for `TextEncoder`
- docs(js): add doc for `TextDecoder`

Relates-To: elide-dev/elide#1044
