### PR TITLE
docs(zlib): add docs for `zlib`, update `os`, `events`, `buffer`

### DIFF
--- a/Writerside/e.tree
+++ b/Writerside/e.tree
@@ -29,7 +29,7 @@
                 <toc-element topic="Node-API.md">
                     <toc-element topic="node-assert.md"/>
                     <toc-element toc-title="Async Hooks" />
-                    <toc-element toc-title="Buffer" />
+                    <toc-element topic="node-buffer.md" />
                     <toc-element topic="node-childprocess.md"/>
                     <toc-element toc-title="Crypto" />
                     <toc-element toc-title="DNS" />
@@ -59,7 +59,7 @@
                     <toc-element toc-title="VM" />
                     <toc-element toc-title="WASI" />
                     <toc-element toc-title="Worker threads" />
-                    <toc-element toc-title="Zlib" />
+                    <toc-element topic="node-zlib.md" />
                 </toc-element>
                 <toc-element toc-title="Web &amp; JavaScript APIs">
                     <toc-element topic="JavaScript-Encoding-API.md"/>

--- a/Writerside/topics/node-buffer.md
+++ b/Writerside/topics/node-buffer.md
@@ -11,10 +11,10 @@ API support and documentation for the `node:buffer` module.
     </tab>
 </tabs>
 
-| Specification | Module        | Support                                                                    | Documentation                                             |
-|---------------|---------------|----------------------------------------------------------------------------|-----------------------------------------------------------|
-| Node.js API   | `node:buffer` | ![Not implemented](https://img.shields.io/badge/-Not%20implemented-yellow) | [Node.js Buffer Docs](https://nodejs.org/api/buffer.html) |
+| Specification | Module        | Support                 | Documentation                                             |
+|---------------|---------------|-------------------------|-----------------------------------------------------------|
+| Node.js API   | `node:buffer` | 🟡 Partially supported. | [Node.js Buffer Docs](https://nodejs.org/api/buffer.html) |
 
 ## Methods
 
-Coming soon.
+Use `Buffer.from` as you do in Node.js. More docs are coming soon.

--- a/Writerside/topics/node-events.md
+++ b/Writerside/topics/node-events.md
@@ -11,9 +11,9 @@ API support and documentation for the `node:events` module.
     </tab>
 </tabs>
 
-| Specification | Module        | Support                                                                    | Documentation                                             |
-|---------------|---------------|----------------------------------------------------------------------------|-----------------------------------------------------------|
-| Node.js API   | `node:events` | ![Not implemented](https://img.shields.io/badge/-Not%20implemented-yellow) | [Node.js Events Docs](https://nodejs.org/api/events.html) |
+| Specification | Module        | Support                 | Documentation                                             |
+|---------------|---------------|-------------------------|-----------------------------------------------------------|
+| Node.js API   | `node:events` | 🟡 Partially supported. | [Node.js Events Docs](https://nodejs.org/api/events.html) |
 
 ## Methods
 

--- a/Writerside/topics/node-os.md
+++ b/Writerside/topics/node-os.md
@@ -47,7 +47,7 @@ API support and documentation for the `node:os` module.
 : 🟢 Supported.
 
 [`getPriority([pid])`](https://nodejs.org/api/os.html#osgetprioritypid)
-: 🔴 Not implemented.
+: 🟢 Supported.
 
 [`homedir()`](https://nodejs.org/api/os.html#oshomedir)
 : 🟢 Supported.
@@ -71,7 +71,7 @@ API support and documentation for the `node:os` module.
 : 🟡 Implemented; not yet compliant.
 
 [`setPriority([pid, ]priority)`](https://nodejs.org/api/os.html#ossetprioritypid-priority)
-: 🔴 Not implemented.
+: 🟢 Supported.
 
 [`tmpdir()`](https://nodejs.org/api/os.html#ostmpdir)
 : 🟢 Supported.
@@ -86,15 +86,7 @@ API support and documentation for the `node:os` module.
 : 🟢 Supported.
 
 [`userInfo([options])`](https://nodejs.org/api/os.html#osuserinfooptions)
-: 🔴 Not implemented.
+: 🟢 Supported.
 
 [`version()`](https://nodejs.org/api/os.html#osversion)
 : 🟡 Implemented; not yet compliant.
-
---
-
-[`appendFile(path, data[, options], callback)`](https://nodejs.org/api/fs.html#fsappendfilepath-data-options-callback)
-: 🔴 Not implemented.
-
-[`readFile(path[, options], callback)`](https://nodejs.org/api/fs.html#fsreadfilepath-options-callback)
-: 🟡 Supported for UTF-8 reads. Binary reads do not work yet.

--- a/Writerside/topics/node-zlib.md
+++ b/Writerside/topics/node-zlib.md
@@ -1,0 +1,159 @@
+---
+switcher-label: Imports
+---
+
+# Zlib
+
+API support and documentation for the `node:zlib`.
+
+<tldr>
+    <p>Modules: <code>node:zlib</code></p>
+    <p>Support: <img style="inline" src="https://img.shields.io/badge/-alpha-blue" /></p>
+    <p>Docs: <a href="https://nodejs.org/api/zlib.html">Node.js Zlib Docs</a></p>
+</tldr>
+
+<code-block lang="javascript" switcher-key="ESM">import zlib from "node:zlib"</code-block>
+<code-block lang="javascript" switcher-key="CJS">const zlib = require("node:zlib")</code-block>
+
+## Modules
+
+| Status                  | Module             | Docs                                     |
+|-------------------------|--------------------|------------------------------------------|
+| 🟡 Partially supported. | `node:zlib`        | [Zlib](https://nodejs.org/api/zlib.html) |
+
+## `zlib` | Classes
+
+[`Options`](https://nodejs.org/docs/latest/api/zlib.html#class-options)
+: 🟡 Supported, but options are not applied yet.
+
+[`BrotliOptions`](https://nodejs.org/docs/latest/api/zlib.html#class-brotlioptions)
+: 🟡 Supported, but options are not applied yet.
+
+[`BrotliCompress`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibbrotlicompress)
+: 🟢 Supported.
+
+[`BrotliDecompress`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibbrotlidecompress)
+: 🟢 Supported.
+
+[`Deflate`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibdeflate)
+: 🟢 Supported.
+
+[`DeflateRaw`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibdeflateraw)
+: 🔴 Not implemented.
+
+[`Gunzip`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibgunzip)
+: 🟢 Supported.
+
+[`Gzip`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibgzip)
+: 🟢 Supported.
+
+[`Inflate`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibinflate)
+: 🟢 Supported.
+
+[`InflateRaw`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibinflateraw)
+: 🔴 Not implemented.
+
+[`Unzip`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibunzip)
+: 🟢 Supported.
+
+[`ZlibBase`](https://nodejs.org/docs/latest/api/zlib.html#class-zlibzlibbase)
+: 🔴 Not implemented.
+
+## `zlib` | Properties
+
+[`constants`](https://nodejs.org/docs/latest/api/zlib.html#zlibconstants)
+: 🟢 Supported.
+
+## `zlib` | Methods
+
+[`crc32(data[, value])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcrc32data-value)
+: 🟢 Supported.
+
+### Streams
+
+These methods create streams which compress or decompress data.
+
+[`createBrotliCompress([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreatebrotlicompressoptions)
+: 🟢 Supported.
+
+[`createBrotliDecompress([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreatebrotlidecompressoptions)
+: 🟢 Supported.
+
+[`createDeflate([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreatedeflateoptions)
+: 🟢 Supported.
+
+[`createDeflateRaw([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreatedeflaterawoptions)
+: 🔴 Not implemented.
+
+[`createGunzip([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreategunzipoptions)
+: 🟢 Supported.
+
+[`createGzip([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreategzipoptions)
+: 🟢 Supported.
+
+[`createInflate([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreateinflateoptions)
+: 🟢 Supported.
+
+[`createInflateRaw([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreateinflaterawoptions)
+: 🔴 Not implemented.
+
+[`createUnzip([options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibcreateunzipoptions)
+: 🟢 Supported.
+
+### Convenience
+
+These methods compress or decompress data.
+
+[`brotliCompress(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibbrotlicompressbuffer-options-callback)
+: 🟢 Supported.
+
+[`brotliCompressSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibbrotlicompresssyncbuffer-options)
+: 🟢 Supported.
+
+[`brotliDecompress(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibbrotlidecompressbuffer-options-callback)
+: 🟢 Supported.
+
+[`brotliDecompressSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibbrotlidecompresssyncbuffer-options)
+: 🟢 Supported.
+
+[`deflate(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibdeflatebuffer-options-callback)
+: 🟢 Supported.
+
+[`deflateSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibdeflatesyncbuffer-options)
+: 🟢 Supported.
+
+[`deflateRaw(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibdeflaterawbuffer-options-callback)
+: 🔴 Not implemented.
+
+[`deflateRawSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibdeflaterawsyncbuffer-options)
+: 🔴 Not implemented.
+
+[`gunzip(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibgunzipbuffer-options-callback)
+: 🟢 Supported.
+
+[`gunzipSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibgunzipsyncbuffer-options)
+: 🟢 Supported.
+
+[`gzip(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibgzipbuffer-options-callback)
+: 🟢 Supported.
+
+[`gzipSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibgzipsyncbuffer-options)
+: 🟢 Supported.
+
+[`inflate(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibinflatebuffer-options-callback)
+: 🟢 Supported.
+
+[`inflateSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibinflatesyncbuffer-options)
+: 🟢 Supported.
+
+[`inflateRaw(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibinflaterawbuffer-options-callback)
+: 🔴 Not implemented.
+
+[`inflateRawSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibinflaterawsyncbuffer-options)
+: 🔴 Not implemented.
+
+[`unzip(buffer[, options], callback)`](https://nodejs.org/docs/latest/api/zlib.html#zlibunzipbuffer-options-callback)
+: 🟢 Supported.
+
+[`unzipSync(buffer[, options])`](https://nodejs.org/docs/latest/api/zlib.html#zlibunzipsyncbuffer-options)
+: 🟢 Supported.


### PR DESCRIPTION
Updates docs for `os`, `events`, and `buffer`; adds docs for the new `zlib` module implementation (all related to the Node API). Waiting on upstream PR elide-dev/elide#1199.