### PR TITLE
docs: prep and release `1.0.0-beta2`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ env:
   ALGOLIA_APP_NAME: '6PJZ7B6YKU'
   ALGOLIA_INDEX_NAME: 'dev_elide_docs'
   CONFIG_JSON_PRODUCT: 'E'
-  CONFIG_JSON_VERSION: '1.0.0-beta1'
+  CONFIG_JSON_VERSION: '1.0.0-beta2'
 
 jobs:
   build:

--- a/Writerside/e.tree
+++ b/Writerside/e.tree
@@ -86,7 +86,8 @@
         <toc-element topic="Performance.md"/>
     </toc-element>
     <toc-element toc-title="Release Notes">
-        <toc-element toc-title="1.0.0-beta1" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta1" />
+        <toc-element toc-title="1.0.0-beta2" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta2" />
+	<toc-element toc-title="1.0.0-beta1" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta1" />
         <toc-element toc-title="1.0.0-alpha14" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-alpha14" />
         <toc-element toc-title="1.0.0-alpha13" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-alpha13" />
         <toc-element toc-title="1.0.0-alpha12" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-alpha12" />
@@ -105,8 +106,8 @@
     <toc-element topic="CLI-Reference.md"/>
     <toc-element topic="Contributors.md"/>
     <toc-element topic="humans.md"/>
-    <toc-element toc-title="Binary Report" href="https://dl.elide.dev/cli/v1/snapshot/linux-amd64/1.0.0-beta1/elide-build-report.html" />
-    <toc-element toc-title="SBOM" href="https://dl.elide.dev/cli/v1/snapshot/linux-amd64/1.0.0-beta1/elide.sbom.json" />
+    <toc-element toc-title="Binary Report" href="https://dl.elide.dev/cli/v1/snapshot/linux-amd64/1.0.0-beta2/elide.build-report.html" />
+    <toc-element toc-title="SBOM" href="https://dl.elide.dev/cli/v1/snapshot/linux-amd64/1.0.0-beta2/elide.sbom.json" />
     <toc-element toc-title="API Docs" href="https://docs.elide.dev/apidocs/index.html" />
     <toc-element toc-title="Elide on Discord" href="https://elide.dev/discord" />
     <toc-element toc-title="Elide on GitHub" href="https://elide.dev/github" />

--- a/Writerside/topics/101-Filesystem.md
+++ b/Writerside/topics/101-Filesystem.md
@@ -49,6 +49,3 @@ We're going to try out %product%'s isolation with regard to **disk I/O**
 
    Neat! We can read the file.
 
-> Node's `fs` and `fs/promises` modules do not yet support I/O isolation. This feature is under construction and is
-> expected to land in `1.0.0-alpha10` or `1.0.0-beta1`.
-> {style="warning"}

--- a/Writerside/topics/Installation.md
+++ b/Writerside/topics/Installation.md
@@ -86,7 +86,7 @@ docker run --rm -it ghcr.io/elide-dev/bash
     with:
       # any tag from the `elide-dev/releases` repo.
       # omit a version to use the latest version.
-      version: 1.0.0-beta1
+      version: 1.0.0-beta2
 ```
 
 ## Troubleshooting

--- a/Writerside/v.list
+++ b/Writerside/v.list
@@ -3,7 +3,7 @@
 <vars>
     <var name="product" value="Elide"/>
     <var name="cli" value="elide"/>
-    <var name="version" value="1.0.0-beta1"/>
+    <var name="version" value="1.0.0-beta2"/>
     <var name="elideDocsSite" value="https://docs.elide.dev"/>
     <var name="elideSite" value="https://elide.dev"/>
     <var name="elideGitHubOrg" value="https://github.com/elide-dev"/>

--- a/Writerside/writerside.cfg
+++ b/Writerside/writerside.cfg
@@ -7,5 +7,5 @@
     <images dir="images" web-path="docs"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="e.tree" version="1.0.0-beta1" web-path="E" />
+    <instance src="e.tree" version="1.0.0-beta2" web-path="E" />
 </ihp>


### PR DESCRIPTION
Plain version bump with some cleanup.