### PR TITLE
chore: bump version → `1.0.0-beta4`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ env:
   ALGOLIA_APP_NAME: '6PJZ7B6YKU'
   ALGOLIA_INDEX_NAME: 'dev_elide_docs'
   CONFIG_JSON_PRODUCT: 'E'
-  CONFIG_JSON_VERSION: '1.0.0-beta3'
+  CONFIG_JSON_VERSION: '1.0.0-beta4'
 
 jobs:
   build:

--- a/Writerside/e.tree
+++ b/Writerside/e.tree
@@ -86,9 +86,10 @@
         <toc-element topic="Performance.md"/>
     </toc-element>
     <toc-element toc-title="Release Notes">
-	<toc-element toc-title="1.0.0-beta3" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta3" />
+        <toc-element toc-title="1.0.0-beta4" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta4" />
+	    <toc-element toc-title="1.0.0-beta3" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta3" />
         <toc-element toc-title="1.0.0-beta2" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta2" />
-	<toc-element toc-title="1.0.0-beta1" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta1" />
+	    <toc-element toc-title="1.0.0-beta1" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta1" />
         <toc-element toc-title="1.0.0-alpha14" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-alpha14" />
         <toc-element toc-title="1.0.0-alpha13" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-alpha13" />
         <toc-element toc-title="1.0.0-alpha12" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-alpha12" />

--- a/Writerside/topics/Installation.md
+++ b/Writerside/topics/Installation.md
@@ -86,7 +86,7 @@ docker run --rm -it ghcr.io/elide-dev/bash
     with:
       # any tag from the `elide-dev/releases` repo.
       # omit a version to use the latest version.
-      version: 1.0.0-beta3
+      version: 1.0.0-beta4
 ```
 
 ## Troubleshooting

--- a/Writerside/v.list
+++ b/Writerside/v.list
@@ -3,7 +3,7 @@
 <vars>
     <var name="product" value="Elide"/>
     <var name="cli" value="elide"/>
-    <var name="version" value="1.0.0-beta3"/>
+    <var name="version" value="1.0.0-beta4"/>
     <var name="elideDocsSite" value="https://docs.elide.dev"/>
     <var name="elideSite" value="https://elide.dev"/>
     <var name="elideGitHubOrg" value="https://github.com/elide-dev"/>

--- a/Writerside/writerside.cfg
+++ b/Writerside/writerside.cfg
@@ -7,5 +7,5 @@
     <images dir="images" web-path="docs"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="e.tree" version="1.0.0-beta3" web-path="E" />
+    <instance src="e.tree" version="1.0.0-beta4" web-path="E" />
 </ihp>


### PR DESCRIPTION
Preps and releases `1.0.0-beta4`, which just has bugfixes.