### PR TITLE
chore: bump version → `1.0.0-beta7`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ env:
   ALGOLIA_APP_NAME: '6PJZ7B6YKU'
   ALGOLIA_INDEX_NAME: 'dev_elide_docs'
   CONFIG_JSON_PRODUCT: 'E'
-  CONFIG_JSON_VERSION: '1.0.0-beta6'
+  CONFIG_JSON_VERSION: '1.0.0-beta7'
 
 jobs:
   build:

--- a/Writerside/e.tree
+++ b/Writerside/e.tree
@@ -86,6 +86,7 @@
         <toc-element topic="Performance.md"/>
     </toc-element>
     <toc-element toc-title="Release Notes">
+        <toc-element toc-title="1.0.0-beta7" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta7" />
         <toc-element toc-title="1.0.0-beta6" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta6" />
         <toc-element toc-title="1.0.0-beta5" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta5" />
         <toc-element toc-title="1.0.0-beta4" href="https://github.com/elide-dev/elide/releases/tag/1.0.0-beta4" />
@@ -110,8 +111,8 @@
     <toc-element topic="CLI-Reference.md"/>
     <toc-element topic="Contributors.md"/>
     <toc-element topic="humans.md"/>
-    <toc-element toc-title="Binary Report" href="https://dl.elide.dev/cli/v1/snapshot/linux-amd64/1.0.0-beta3/elide.build-report.html" />
-    <toc-element toc-title="SBOM" href="https://dl.elide.dev/cli/v1/snapshot/linux-amd64/1.0.0-beta3/elide.sbom.json" />
+    <toc-element toc-title="Binary Report" href="https://dl.elide.dev/cli/v1/snapshot/linux-amd64/1.0.0-beta7/elide.build-report.html" />
+    <toc-element toc-title="SBOM" href="https://dl.elide.dev/cli/v1/snapshot/linux-amd64/1.0.0-beta7/elide.sbom.json" />
     <toc-element toc-title="API Docs" href="https://docs.elide.dev/apidocs/index.html" />
     <toc-element toc-title="Elide on Discord" href="https://elide.dev/discord" />
     <toc-element toc-title="Elide on GitHub" href="https://elide.dev/github" />

--- a/Writerside/topics/Installation.md
+++ b/Writerside/topics/Installation.md
@@ -86,7 +86,7 @@ docker run --rm -it ghcr.io/elide-dev/bash
     with:
       # any tag from the `elide-dev/releases` repo.
       # omit a version to use the latest version.
-      version: 1.0.0-beta6
+      version: 1.0.0-beta7
 ```
 
 ## Troubleshooting

--- a/Writerside/v.list
+++ b/Writerside/v.list
@@ -3,7 +3,7 @@
 <vars>
     <var name="product" value="Elide"/>
     <var name="cli" value="elide"/>
-    <var name="version" value="1.0.0-beta6"/>
+    <var name="version" value="1.0.0-beta7"/>
     <var name="elideDocsSite" value="https://docs.elide.dev"/>
     <var name="elideSite" value="https://elide.dev"/>
     <var name="elideGitHubOrg" value="https://github.com/elide-dev"/>

--- a/Writerside/writerside.cfg
+++ b/Writerside/writerside.cfg
@@ -7,5 +7,5 @@
     <images dir="images" web-path="docs"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="e.tree" version="1.0.0-beta6" web-path="E" />
+    <instance src="e.tree" version="1.0.0-beta7" web-path="E" />
 </ihp>


### PR DESCRIPTION
Releases docs at `1.0.0-beta7`.